### PR TITLE
Updating install_requires to resolve nbsphinx module not found error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from setuptools import find_packages, setup
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 def package_files(
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         'sphinx==5.1.1',
         'sphinx_rtd_theme>=1.0',
+        'nbsphinx',
     ],
     package_data={
         'pyg_sphinx_theme': [


### PR DESCRIPTION
Following [doc build directions](https://github.com/zach-blumenfeld/pytorch_geometric/blob/master/docs/README.md) this fails with below.  Adding module to install_requires seems to fix

```
(pytorch_geometric) (base) zachblumenfeld:~/proj/pytorch_geometric/docs (master) $ make html
Running Sphinx v5.1.1

Extension error:
Could not import extension nbsphinx (exception: No module named 'nbsphinx')
make: *** [html] Error 2
```